### PR TITLE
Add focus states

### DIFF
--- a/style.css
+++ b/style.css
@@ -46,7 +46,7 @@
 /* Fonts below are recreations by Giles Booth */
 @font-face {
   font-family: Chicago_12;
-  src: url("fonts/ChiKareGo2.ttf"); 
+  src: url("fonts/ChiKareGo2.ttf");
 }
 @font-face {
   font-family: Geneva_9;
@@ -408,6 +408,24 @@ input  {
 
 input:focus  {
   outline:none;
+}
+
+input[type="text"]:focus,
+input[type="email"]:focus,
+input[type="password"]:focus,
+input[type="number"]:focus,
+input[type="date"]:focus,
+input[type="time"]:focus,
+input[type="datetime"]:focus,
+input[type="datetime-local"]:focus,
+input[type="month"]:focus,
+input[type="week"]:focus,
+input[type="search"]:focus,
+input[type="tel"]:focus,
+input[type="color"]:focus,
+textarea:focus {
+  background: #000;
+  color: #fff;
 }
 
 input[type="radio"] + label::before {

--- a/style.css
+++ b/style.css
@@ -410,19 +410,19 @@ input:focus  {
   outline:none;
 }
 
-input[type="text"]:focus,
-input[type="email"]:focus,
-input[type="password"]:focus,
-input[type="number"]:focus,
-input[type="date"]:focus,
-input[type="time"]:focus,
-input[type="datetime"]:focus,
-input[type="datetime-local"]:focus,
-input[type="month"]:focus,
-input[type="week"]:focus,
-input[type="search"]:focus,
-input[type="tel"]:focus,
-input[type="color"]:focus,
+input[type="text"]:focus-visible,
+input[type="email"]:focus-visible,
+input[type="password"]:focus-visible,
+input[type="number"]:focus-visible,
+input[type="date"]:focus-visible,
+input[type="time"]:focus-visible,
+input[type="datetime"]:focus-visible,
+input[type="datetime-local"]:focus-visible,
+input[type="month"]:focus-visible,
+input[type="week"]:focus-visible,
+input[type="search"]:focus-visible,
+input[type="tel"]:focus-visible,
+input[type="color"]:focus-visible,
 textarea:focus {
   background: #000;
   color: #fff;
@@ -475,7 +475,8 @@ input[type="radio"] + label::before {
   background: svg-load("./icon/radio-border.svg");
 }
 
-input[type="radio"]:focus-visible + label::before {
+input[type="radio"]:focus-visible + label::before,
+input[type="radio"]:hover + label::before {
   background-image: svg-load("./icon/radio-border-focused.svg");
 }
 
@@ -507,7 +508,8 @@ input[type="checkbox"] + label::before {
   margin-right: var(--radio-label-spacing);
 }
 
-input[type="checkbox"]:focus-visible + label::before {
+input[type="checkbox"]:focus-visible + label::before,
+input[type="checkbox"]:hover + label::before {
   outline: 1px solid black;
 }
 


### PR DESCRIPTION
This PR adds focus states for keyboard to add accessibility conformance and improves some hover states across the inputs. 
It also adjusts the text input fields to match behavior in the [archive.org emulator for System 6](https://archive.org/details/mac_MacOS_6.0.8)