### PR TITLE
Add style to docs 'Show code'

### DIFF
--- a/docs/docs.css
+++ b/docs/docs.css
@@ -116,6 +116,9 @@ blockquote footer {
 summary {
   font-size: 14px;
   padding-top: 10px;
+  cursor: pointer;
+  margin: 12px 0 0 0;
+  width: 30%;
 }
 
 pre {


### PR DESCRIPTION
### Docs update
I have updated the docs to show a pointer when you hover over the 'Show code' section. This differentiates it from normal text. 

#### Demo
<img width="719" alt="with-pointer" src="https://user-images.githubusercontent.com/27485722/198115717-407d4a06-aadc-4e66-8b44-9e0f6a479b4d.png">
<img width="719" alt="without-pointer" src="https://user-images.githubusercontent.com/27485722/198115757-f6544137-9c4c-4d53-954d-7ee62d0ef4e3.png">

(Would appreciate hacktoberfest label)
